### PR TITLE
nim: fix mobileFibonacci

### DIFF
--- a/mobile-app/modules/nim-bridge/android/src/main/cpp/NimBridge.cpp
+++ b/mobile-app/modules/nim-bridge/android/src/main/cpp/NimBridge.cpp
@@ -6,7 +6,7 @@ extern "C" {
     const char* helloWorld();
     int addNumbers(int a, int b);
     const char* getSystemInfo();
-    int mobileFibonacci(int n);
+    long long mobileFibonacci(int n);
     int mobileIsPrime(int n);
     const char* mobileFactorize(int n);
     const char* mobileCreateUser(int id, const char* name, const char* email);
@@ -49,10 +49,10 @@ Java_com_nimbridge_NimBridgeModule_nativeGetSystemInfo(JNIEnv *env, jclass clazz
     return javaString;
 }
 
-extern "C" JNIEXPORT jint JNICALL
+extern "C" JNIEXPORT jlong JNICALL
 Java_com_nimbridge_NimBridgeModule_nativeMobileFibonacci(JNIEnv *env, jclass clazz, jint n) {
     initializeNim();
-    return mobileFibonacci(n);
+    return (jlong)mobileFibonacci(n);
 }
 
 extern "C" JNIEXPORT jint JNICALL

--- a/mobile-app/modules/nim-bridge/android/src/main/cpp/nim_functions.h
+++ b/mobile-app/modules/nim-bridge/android/src/main/cpp/nim_functions.h
@@ -16,7 +16,7 @@ extern "C" {
     NCSTRING helloWorld();
     int addNumbers(int a, int b);
     NCSTRING getSystemInfo();
-    int mobileFibonacci(int n);
+    long long mobileFibonacci(int n);
     int mobileIsPrime(int n);
     NCSTRING mobileFactorize(int n);
     NCSTRING mobileCreateUser(int id, NCSTRING name, NCSTRING email);

--- a/mobile-app/modules/nim-bridge/android/src/main/java/com/nimbridge/NimBridgeModule.java
+++ b/mobile-app/modules/nim-bridge/android/src/main/java/com/nimbridge/NimBridgeModule.java
@@ -34,7 +34,7 @@ public class NimBridgeModule extends ReactContextBaseJavaModule {
     private static native String nativeHelloWorld();
     private static native int nativeAddNumbers(int a, int b);
     private static native String nativeGetSystemInfo();
-    private static native int nativeMobileFibonacci(int n);
+    private static native long nativeMobileFibonacci(int n);
     private static native int nativeMobileIsPrime(int n);
     private static native String nativeMobileFactorize(int n);
     private static native String nativeMobileCreateUser(int id, String name, String email);

--- a/mobile-app/modules/nim-bridge/ios/NimBridge.mm
+++ b/mobile-app/modules/nim-bridge/ios/NimBridge.mm
@@ -52,7 +52,7 @@ RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(NSString *, getSystemInfo)
 
 RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(NSNumber *, mobileFibonacci:(nonnull NSNumber *)n)
 {
-    int result = mobileFibonacci([n intValue]);
+    long long result = mobileFibonacci([n intValue]);
     return @(result);
 }
 

--- a/mobile-app/modules/nim-bridge/ios/nim_functions.h
+++ b/mobile-app/modules/nim-bridge/ios/nim_functions.h
@@ -16,7 +16,7 @@ extern "C" {
     NCSTRING helloWorld();
     int addNumbers(int a, int b);
     NCSTRING getSystemInfo();
-    int mobileFibonacci(int n);
+    long long mobileFibonacci(int n);
     int mobileIsPrime(int n);
     NCSTRING mobileFactorize(int n);
     NCSTRING mobileCreateUser(int id, NCSTRING name, NCSTRING email);

--- a/mobile-app/nim/nimbridge.nim
+++ b/mobile-app/nim/nimbridge.nim
@@ -24,9 +24,15 @@ proc getSystemInfo*(): cstring {.exportc.} =
   let info = fmt"Nim {NimVersion} on iOS (arm64)"
   return allocCString(info)
 
-proc mobileFibonacci*(n: cint): cint {.exportc.} =
-  if n <= 1: return n
-  return mobileFibonacci(n - 1) + mobileFibonacci(n - 2)
+proc mobileFibonacci*(n: cint): int64 {.exportc.} =
+  if n <= 1: return n.int64
+  var a: int64 = 0
+  var b: int64 = 1
+  for i in 2..n:
+    let temp = a + b
+    a = b
+    b = temp
+  return b
 
 proc mobileIsPrime*(n: cint): cint {.exportc.} =
   if n <= 1: return 0

--- a/mobile-app/src/App.tsx
+++ b/mobile-app/src/App.tsx
@@ -49,6 +49,15 @@ const App: React.FC = () => {
     try {
       const num = parseInt(mathInput) || 10;
       
+      // Check for Fibonacci overflow
+      if (num > 78) {
+        Alert.alert(
+          'MATH_PROCESSOR LIMIT',
+          'Fibonacci calculation exceeds JavaScript MAX_SAFE_INTEGER for values > 78. Results will be inaccurate.',
+          [{ text: 'OK' }]
+        );
+      }
+      
       // Test addition
       const sum = NimCore.addNumbers(num, 5);
       addResult(`${num} + 5 = ${sum}`);


### PR DESCRIPTION
## Summary

- existing `mobileFibonacci` used recursion which was terrible for very long numbers, which would cause the app to hang. Fixed by updating its algo and returning `int64 ` instead of `cint`
- add a UI warning for long numbers in math suite
-  updated bindings generator to handle `long long` return types.
- add a prompt in UI to alert users for inaccuracies when entering big numbers.